### PR TITLE
Hide/Show Columns in the Project List output

### DIFF
--- a/NIH/params.cfg
+++ b/NIH/params.cfg
@@ -4,7 +4,8 @@
   , "year_upto": null
   , "year_from": null
   , "orgs": null
-  , "pis": "Kristian Andersen"
+  , "pis": "Kristian Andersen; Eric Topol; "
+  , "hide_pis": false
   , "search_text": null
   , "show_prjs": true
   , "save_results": false

--- a/NIH/params.cfg
+++ b/NIH/params.cfg
@@ -10,4 +10,5 @@
   , "save_results": false
   , "project_nums": null
   , "covid_response_code": "All"
+  , "show_covid_response": true
 }


### PR DESCRIPTION
When List of Projects is displayed, I would like to have ability to control visibility on:
(1) Add new flags to input request: (a) show_covid_response (b) hide_pis
(2) Column covid_response - ensure that this column is displayed, when the request is to filter projects funded through Covid Appropriation(1) Column "contact_pi" - if there is only one, this column can be hidden
(3) Rename the column "contat_pi" heading to "Investigator(s)"
